### PR TITLE
Auto transfer completed registrations

### DIFF
--- a/app/Http/Controllers/ChemicalRegistrationController.php
+++ b/app/Http/Controllers/ChemicalRegistrationController.php
@@ -7,6 +7,8 @@ use App\Models\ChemicalRegistration;
 use App\Models\DrugProgressStep; // Assuming this is the model for drug progress steps
 use Illuminate\Support\Facades\Log; // For logging errors
 use App\Models\Company;
+use App\Models\ChemicalImport;
+use App\Models\ProductionRegistration;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -737,6 +739,22 @@ class ChemicalRegistrationController extends Controller
 
                 $drug->progress = $show_step_number + 12.5;
                 $drug->save();
+            }
+        }
+
+        if ($drug->progress >= 100) {
+            $drug->update(['new_or_old' => false]);
+
+            if (in_array($drug->registration_type, ['T', 'I'])) {
+                ChemicalImport::firstOrCreate(
+                    ['registration_number' => $drug->registration_number],
+                    $drug->only((new ChemicalImport)->getFillable())
+                );
+            } else {
+                ProductionRegistration::firstOrCreate(
+                    ['registration_number' => $drug->registration_number],
+                    $drug->only((new ProductionRegistration)->getFillable())
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- Transfer 100%-complete new registrations into chemical import or production registries depending on registration type
- Mark completed registrations as old and avoid duplicates

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused; Missing application encryption key)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e0631448832385382402c5298f1a