### PR TITLE
Persist PHI radio selections and remarks in step-one flow

### DIFF
--- a/app/Http/Controllers/ChemicalRegistrationController.php
+++ b/app/Http/Controllers/ChemicalRegistrationController.php
@@ -84,12 +84,11 @@ class ChemicalRegistrationController extends Controller
                 'จัดซื้อต่างประเทศ' => ['ทะเบียน', 'ใบอนุญาตในประเทศผู้ผลิต', 'เอกสารอนุญาตอื่นๆ'],
                 'ฝ่ายขาย' => ['รายชื่อผู้ขอขึ้นทะเบียน', 'ชื่อการค้า', 'Packing'],
                 'วิจัยและพัฒนา' => ['เตรียมข้อมูลผลิตตัวอย่าง'],
-                'แผนกวิชาการ' => ['แผนการทดลอง'],
+                'แผนกวิชาการ' => ['แผนการทดลอง', 'หนังสือขอยกเว้น PHI', 'แผน PHI'],
                 'แผนกทะเบียน' => [
                     'ตรวจสอบเอกสารขึ้นทะเบียน',
                     'ตรวจชื่อการค้า',
                     'ขอใบอนุญาตนำเข้าตัวอย่าง',
-                    'อื่นๆ',
                 ],
             ],
         ];
@@ -149,7 +148,7 @@ class ChemicalRegistrationController extends Controller
                 ->where('step_number', 1)
                 ->where('sub_step_index', $planIndex)
                 ->first();
-            $isPlanNone = $planNoteRecord && $planNoteRecord->created_by === 'no';
+            $isPlanNone = $planNoteRecord && $planNoteRecord->created_by === 'ไม่มี';
             $product->isPlanNone = $isPlanNone;
         }
 
@@ -257,12 +256,11 @@ class ChemicalRegistrationController extends Controller
                     'จัดซื้อต่างประเทศ' => ['ทะเบียน', 'ใบอนุญาตในประเทศผู้ผลิต', 'เอกสารอนุญาตอื่นๆ'],
                     'ฝ่ายขาย' => ['รายชื่อผู้ขอขึ้นทะเบียน', 'ชื่อการค้า', 'Packing'],
                     'วิจัยและพัฒนา' => ['เตรียมข้อมูลผลิตตัวอย่าง'],
-                    'แผนกวิชาการ' => ['แผนการทดลอง'],
+                    'แผนกวิชาการ' => ['แผนการทดลอง', 'หนังสือขอยกเว้น PHI', 'แผน PHI'],
                     'แผนกทะเบียน' => [
                         'ตรวจสอบเอกสารขึ้นทะเบียน',
                         'ตรวจชื่อการค้า',
                         'ขอใบอนุญาตนำเข้าตัวอย่าง',
-                        'อื่นๆ',
                     ],
                 ],
             ];
@@ -615,6 +613,7 @@ class ChemicalRegistrationController extends Controller
         $stepNumber = (int) $request->input('step_number');
         $selectedIndexes = $request->input('sub_steps', []);
         $notes = $request->input('sub_step_notes', []);
+        $remarks = $request->input('sub_step_remarks', []);
         $show_step_number = $request->input('progress');
         $drug->progress = $show_step_number;
         $drug->save();
@@ -625,12 +624,11 @@ class ChemicalRegistrationController extends Controller
                 'จัดซื้อต่างประเทศ' => ['ทะเบียน', 'ใบอนุญาตในประเทศผู้ผลิต', 'เอกสารอนุญาตอื่นๆ'],
                 'ฝ่ายขาย' => ['รายชื่อผู้ขอขึ้นทะเบียน', 'ชื่อการค้า', 'Packing'],
                 'วิจัยและพัฒนา' => ['เตรียมข้อมูลผลิตตัวอย่าง'],
-                'แผนกวิชาการ' => ['แผนการทดลอง'],
+                'แผนกวิชาการ' => ['แผนการทดลอง', 'หนังสือขอยกเว้น PHI', 'แผน PHI'],
                 'แผนกทะเบียน' => [
                     'ตรวจสอบเอกสารขึ้นทะเบียน',
                     'ตรวจชื่อการค้า',
                     'ขอใบอนุญาตนำเข้าตัวอย่าง',
-                    'อื่นๆ',
                 ],
             ],
             2 => [
@@ -720,7 +718,7 @@ class ChemicalRegistrationController extends Controller
             ->where('step_number', 1)
             ->where('sub_step_index', $planIndex)
             ->first();
-        $isPlanNone = $planNoteRecord && $planNoteRecord->created_by === 'no';
+        $isPlanNone = $planNoteRecord && $planNoteRecord->created_by === 'ไม่มี';
 
         $stepStructure = $rawStructure[$stepNumber] ?? [];
         $flatItems = [];
@@ -746,6 +744,7 @@ class ChemicalRegistrationController extends Controller
                             'department' => $department,
                             'checked_at' => in_array($index, $selectedIndexes) ? now() : null,
                             'created_by' => $notes[$index] ?? null,
+                            'remark' => $remarks[$index] ?? null,
                         ]
                     );
                 }

--- a/app/Models/ChemicalRegistration.php
+++ b/app/Models/ChemicalRegistration.php
@@ -104,6 +104,6 @@ class ChemicalRegistration extends Model
     public function checkPlan($id)
     {
         return DrugProgressStep::where('chemical_registrations_id', $id)
-            ->where('created_by', 'yes')->exists();
+            ->where('created_by', 'มี')->exists();
     }
 }

--- a/app/Models/DrugProgressStep.php
+++ b/app/Models/DrugProgressStep.php
@@ -15,6 +15,7 @@ class DrugProgressStep extends Model
         'department',
         'checked_at',
         'created_by',
+        'remark',
     ];
 
     public function drug()

--- a/database/migrations/2025_07_03_000001_add_remark_to_drug_progress_steps_table.php
+++ b/database/migrations/2025_07_03_000001_add_remark_to_drug_progress_steps_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('drug_progress_steps', function (Blueprint $table) {
+            $table->string('remark')->nullable()->after('created_by');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('drug_progress_steps', function (Blueprint $table) {
+            $table->dropColumn('remark');
+        });
+    }
+};

--- a/resources/views/product/new/edit.blade.php
+++ b/resources/views/product/new/edit.blade.php
@@ -622,12 +622,11 @@
                                     'จัดซื้อต่างประเทศ' => ['ทะเบียน', 'ใบอนุญาตในประเทศผู้ผลิต', 'เอกสารอนุญาตอื่นๆ'],
                                     'ฝ่ายขาย' => ['รายชื่อผู้ขอขึ้นทะเบียน', 'ชื่อการค้า', 'Packing'],
                                     'วิจัยและพัฒนา' => ['เตรียมข้อมูลผลิตตัวอย่าง'],
-                                    'แผนกวิชาการ' => ['แผนการทดลอง'],
+                                    'แผนกวิชาการ' => ['แผนการทดลอง', 'หนังสือขอยกเว้น PHI', 'แผน PHI'],
                                     'แผนกทะเบียน' => [
                                         'ตรวจสอบเอกสารขึ้นทะเบียน',
                                         'ตรวจชื่อการค้า',
                                         'ขอใบอนุญาตนำเข้าตัวอย่าง',
-                                        'อื่นๆ',
                                     ],
                                 ],
                             ],
@@ -721,10 +720,8 @@
                             ],
                         ];
 
-                        // ดึงค่าจาก "แผนการทดลอง" ในขั้นตอนที่ 1
-                        $planIndex = collect($subStepsAll[1]['items'])->flatten()->search('แผนการทดลอง');
-                        $planNote = $checkplan;
-                        $hideAcademicSteps = $planNote == 'ไม่มี';
+                        // ไม่ต้องซ่อนขั้นตอนแผนกวิชาการตาม "แผนการทดลอง" อีกต่อไป
+                        $hideAcademicSteps = false;
 
                         // เก็บ flag ว่าขั้นตอนใดทำครบแล้วบ้าง
                         $completedStepFlags = [];
@@ -894,11 +891,12 @@
                                                     </h5>
                                                     <div class="space-y-2 pl-4">
                                                         @foreach ($subItems as $label)
-                                                            @php
-                                                                $record = $savedSubSteps[$checkboxIndex] ?? null;
-                                                                $isChecked = $record && $record->checked_at;
-                                                                // $checkplan = $record->note ?? '';
-                                                            @endphp
+                                                                @php
+                                                                    $record = $savedSubSteps[$checkboxIndex] ?? null;
+                                                                    $isChecked = $record && $record->checked_at;
+                                                                    $note = $record->created_by ?? '';
+                                                                    $remark = $record->remark ?? '';
+                                                                @endphp
                                                             <div class="flex flex-col gap-1">
                                                                 <div class="flex items-center space-x-3">
                                                                     <input type="checkbox" name="sub_steps[]"
@@ -913,7 +911,7 @@
                                                                         class="text-sm text-gray-800">{{ $label }}</label>
                                                                 </div>
 
-                                                                @if ($label === 'แผนการทดลอง')
+                                                                @if (in_array($label, ['หนังสือขอยกเว้น PHI', 'แผน PHI']))
                                                                     <div id="radio_container_{{ $stepNumber }}_{{ $checkboxIndex }}"
                                                                         class="ml-6 mt-2 space-x-4"
                                                                         style="{{ $isChecked ? '' : 'display: none;' }}">
@@ -921,23 +919,33 @@
                                                                             <input type="radio"
                                                                                 class="form-radio text-green-500 w-5 h-5"
                                                                                 name="sub_step_notes[{{ $checkboxIndex }}]"
-                                                                                value="no"
-                                                                                {{ $checkplan == 'ไม่มี' ? 'checked' : '' }}
+                                                                                value="ไม่มี"
+                                                                                {{ $note == 'ไม่มี' ? 'checked' : '' }}
                                                                                 {{ !$isEditable ? 'disabled' : '' }}>
-                                                                            <span
-                                                                                class="ml-2 text-gray-800">ไม่มี</span>
+                                                                            <span class="ml-2 text-gray-800">ไม่มี</span>
                                                                         </label>
                                                                         <label class="inline-flex items-center">
                                                                             <input type="radio"
                                                                                 class="form-radio text-yellow-500 w-5 h-5"
                                                                                 name="sub_step_notes[{{ $checkboxIndex }}]"
-                                                                                value="yes"
-                                                                                {{ $checkplan == 'มี' ? 'checked' : '' }}
+                                                                                value="มี"
+                                                                                {{ $note == 'มี' ? 'checked' : '' }}
                                                                                 {{ !$isEditable ? 'disabled' : '' }}>
                                                                             <span class="ml-2 text-gray-800">มี</span>
                                                                         </label>
                                                                     </div>
                                                                 @endif
+
+                                                                <div id="remark_container_{{ $stepNumber }}_{{ $checkboxIndex }}"
+                                                                    class="ml-6 mt-2"
+                                                                    style="{{ $isChecked ? '' : 'display: none;' }}">
+                                                                    <input type="text"
+                                                                        name="sub_step_remarks[{{ $checkboxIndex }}]"
+                                                                        value="{{ $remark }}"
+                                                                        placeholder="หมายเหตุ"
+                                                                        class="w-full p-2 border rounded-md"
+                                                                        {{ !$isEditable ? 'disabled' : '' }}>
+                                                                </div>
                                                             </div>
                                                             @php $checkboxIndex++; @endphp
                                                         @endforeach
@@ -1048,26 +1056,31 @@
     <script>
         document.getElementById('menu-newregis')?.classList.add('side-menu--active');
 
-        // Store the last selected radio value for each "แผนการทดลอง" checkbox
+        // Store the last selected radio value for each checkbox with radio options
         const lastSelectedRadioValue = {};
 
         function toggleInput(stepNumber, checkboxIndex) {
             const checkbox = document.getElementById(`substep_${stepNumber}_${checkboxIndex}`);
             const radioContainer = document.getElementById(`radio_container_${stepNumber}_${checkboxIndex}`);
+            const remarkContainer = document.getElementById(`remark_container_${stepNumber}_${checkboxIndex}`);
 
-            if (checkbox && radioContainer) {
-                if (checkbox.checked) {
-                    radioContainer.style.display = ''; // Show the div
+            if (!checkbox) return;
 
-                    // Restore the last selected value, or default to 'no' (ไม่มี)
-                    const savedValue = lastSelectedRadioValue[`${stepNumber}_${checkboxIndex}`] || 'no';
+            if (checkbox.checked) {
+                if (radioContainer) {
+                    radioContainer.style.display = '';
 
+                    const savedValue = lastSelectedRadioValue[`${stepNumber}_${checkboxIndex}`] || 'ไม่มี';
                     const radios = radioContainer.querySelectorAll('input[type="radio"]');
                     radios.forEach(radio => {
                         radio.checked = (radio.value === savedValue);
                     });
-                } else {
-                    // When unchecked, save the currently selected radio button value
+                }
+                if (remarkContainer) {
+                    remarkContainer.style.display = '';
+                }
+            } else {
+                if (radioContainer) {
                     const currentRadios = radioContainer.querySelectorAll('input[type="radio"]');
                     currentRadios.forEach(radio => {
                         if (radio.checked) {
@@ -1075,9 +1088,13 @@
                         }
                     });
 
-                    radioContainer.style.display = 'none'; // Hide the div
-                    // Optionally, uncheck all radio buttons when the checkbox is unchecked to clear its state
-                    currentRadios.forEach(radio => radio.checked = false);
+                    radioContainer.style.display = 'none';
+                    currentRadios.forEach(radio => (radio.checked = false));
+                }
+                if (remarkContainer) {
+                    const input = remarkContainer.querySelector('input');
+                    if (input) input.value = '';
+                    remarkContainer.style.display = 'none';
                 }
             }
         }

--- a/resources/views/product/new/show.blade.php
+++ b/resources/views/product/new/show.blade.php
@@ -216,12 +216,11 @@
                                         ],
                                         'ฝ่ายขาย' => ['รายชื่อผู้ขอขึ้นทะเบียน', 'ชื่อการค้า', 'Packing'],
                                         'วิจัยและพัฒนา' => ['เตรียมข้อมูลผลิตตัวอย่าง'],
-                                        'แผนกวิชาการ' => ['แผนการทดลอง'],
+                                        'แผนกวิชาการ' => ['แผนการทดลอง', 'หนังสือขอยกเว้น PHI', 'แผน PHI'],
                                         'แผนกทะเบียน' => [
                                             'ตรวจสอบเอกสารขึ้นทะเบียน',
                                             'ตรวจชื่อการค้า',
                                             'ขอใบอนุญาตนำเข้าตัวอย่าง',
-                                            'อื่นๆ',
                                         ],
                                     ],
                                 ],
@@ -441,7 +440,8 @@
                                                                 @php
                                                                     $record = $savedSubSteps[$checkboxIndex] ?? null;
                                                                     $isChecked = $record && $record->checked_at;
-                                                                    // $checkplan = $record->note ?? '';
+                                                                    $note = $record->created_by ?? '';
+                                                                    $remark = $record->remark ?? '';
                                                                 @endphp
                                                                 <div class="flex flex-col gap-1">
                                                                     <div class="flex items-center space-x-3">
@@ -458,7 +458,7 @@
                                                                             class="text-sm text-gray-800">{{ $label }}</label>
                                                                     </div>
 
-                                                                    @if ($label === 'แผนการทดลอง')
+                                                                    @if (in_array($label, ['แผนการทดลอง', 'หนังสือขอยกเว้น PHI', 'แผน PHI']))
                                                                         <div id="radio_container_{{ $stepNumber }}_{{ $checkboxIndex }}"
                                                                             class="ml-6 mt-2 space-x-4"
                                                                             style="{{ $isChecked ? '' : 'display: none;' }}">
@@ -466,24 +466,29 @@
                                                                                 <input disabled type="radio"
                                                                                     class="form-radio text-green-500 w-5 h-5"
                                                                                     name="sub_step_notes[{{ $checkboxIndex }}]"
-                                                                                    value="no"
-                                                                                    {{ $checkplan == 'ไม่มี' ? 'checked' : '' }}
+                                                                                    value="ไม่มี"
+                                                                                    {{ $note == 'ไม่มี' ? 'checked' : '' }}
                                                                                     {{ !$isEditable ? 'disabled' : '' }}>
-                                                                                <span
-                                                                                    class="ml-2 text-gray-800">ไม่มี</span>
+                                                                                <span class="ml-2 text-gray-800">ไม่มี</span>
                                                                             </label>
                                                                             <label class="inline-flex items-center">
-                                                                                <input type="radio"
+                                                                                <input disabled type="radio"
                                                                                     class="form-radio text-yellow-500 w-5 h-5"
                                                                                     name="sub_step_notes[{{ $checkboxIndex }}]"
-                                                                                    value="yes"
-                                                                                    {{ $checkplan == 'มี' ? 'checked' : '' }}
+                                                                                    value="มี"
+                                                                                    {{ $note == 'มี' ? 'checked' : '' }}
                                                                                     {{ !$isEditable ? 'disabled' : '' }}>
-                                                                                <span
-                                                                                    class="ml-2 text-gray-800">มี</span>
+                                                                                <span class="ml-2 text-gray-800">มี</span>
                                                                             </label>
                                                                         </div>
                                                                     @endif
+
+                                                                    <div id="remark_container_{{ $stepNumber }}_{{ $checkboxIndex }}"
+                                                                        class="ml-6 mt-2"
+                                                                        style="{{ $isChecked ? '' : 'display: none;' }}">
+                                                                        <input type="text" value="{{ $remark }}" placeholder="หมายเหตุ"
+                                                                            class="w-full p-2 border rounded-md" disabled>
+                                                                    </div>
                                                                 </div>
                                                                 @php $checkboxIndex++; @endphp
                                                             @endforeach


### PR DESCRIPTION
## Summary
- capture "หนังสือขอยกเว้น PHI" and "แผน PHI" radio choices and show them on edit and detail pages
- support optional remarks for every progress checkbox and store them in a new `remark` column
- update controller to persist both radio and remark values for each sub-step

## Testing
- `composer install --no-interaction --no-progress` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3, current version is 8.4.12)*

------
https://chatgpt.com/codex/tasks/task_e_68c39738e2588323a21009361b359cc3